### PR TITLE
Check the return value from i2c_smbus_write_byte_data()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Raspberry Pi C driver and Python bindings for the sensor BMP180.
 #include "bmp180.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 int main(int argc, char **argv){
 	char *i2c_device = "/dev/i2c-1";
@@ -19,11 +21,29 @@ int main(int argc, char **argv){
 	void *bmp = bmp180_init(address, i2c_device);
 	
 	if(bmp != NULL){
-		int i;
+		int i, error;
 		for(i = 0; i < 10; i++) {
 			float t = bmp180_temperature(bmp);
+			error = bmp180_get_last_errno(bmp);
+			if (error != 0) {
+				printf("Error reading temperature: %s\n", strerror(error));
+				exit(1);
+			}
+
 			long p = bmp180_pressure(bmp);
+			error = bmp180_get_last_errno(bmp);
+			if (error != 0) {
+				printf("Error reading pressure: %s\n", strerror(error));
+				exit(1);
+			}
+
 			float alt = bmp180_altitude(bmp);
+			error = bmp180_get_last_errno(bmp);
+			if (error != 0) {
+				printf("Error reading altitude: %s\n", strerror(error));
+				exit(1);
+			}
+
 			printf("t = %f, p = %lu, a = %f\n", t, p, alt);
 			usleep(2 * 1000 * 1000);
 		}

--- a/src/bmp180.h
+++ b/src/bmp180.h
@@ -42,5 +42,7 @@ float bmp180_temperature(void *_bmp);
 
 float bmp180_altitude(void *_bmp);
 
+int bmp180_get_last_errno(void *_bmp);
+
 void bmp180_dump_eprom(void *_bmp, bmp180_eprom_t *eprom);
 

--- a/src/test.c
+++ b/src/test.c
@@ -1,6 +1,8 @@
 #include "bmp180.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 int main(int argc, char **argv){
 	char *i2c_device = "/dev/i2c-1";
@@ -15,11 +17,29 @@ int main(int argc, char **argv){
 	bmp180_set_oss(bmp, 1);
 	
 	if(bmp != NULL){
-		int i;
+		int i, error;
 		for(i = 0; i < 10; i++) {
 			float t = bmp180_temperature(bmp);
+			error = bmp180_get_last_errno(bmp);
+			if (error != 0) {
+				printf("Error reading temperature: %s\n", strerror(error));
+				exit(1);
+			}
+
 			long p = bmp180_pressure(bmp);
+			error = bmp180_get_last_errno(bmp);
+			if (error != 0) {
+				printf("Error reading pressure: %s\n", strerror(error));
+				exit(1);
+			}
+
 			float alt = bmp180_altitude(bmp);
+			error = bmp180_get_last_errno(bmp);
+			if (error != 0) {
+				printf("Error reading altitude: %s\n", strerror(error));
+				exit(1);
+			}
+
 			printf("t = %f, p = %lu, a= %f\n", t, p, alt);
 			usleep(2 * 1000 * 1000);
 		}


### PR DESCRIPTION
The call to i2c_smbus_write_byte_data() can fail and the return value
was not being checked. This can cause incorrect values to be returned
by the driver. With this change, when calling bmp180_temperature(),
bmp180_pressure() and bmp180_altitude(), the return value will either
be LONG_MIN or -FLT_MAX, depending on the return data type if the
operation failed. The caller can call bmp180_get_last_errno() to get
the errno of the failed operation.

I am encountering this situation with my BMP180 sensor. It is
currently outdoors and I believe that moisture may be causing an
issue with the sensor. `i2cdetect 1` does not show the sensor, however
the test program will return values like:
t = 12.800000, p = 99977, a= 112.836433
